### PR TITLE
soft-force toolchain version

### DIFF
--- a/os/rust-toolchain.toml
+++ b/os/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly-2025-10-01"
+profile = "minimal"
+components = ["cargo", "clippy", "rustc", "rustfmt", "rust-src"]
+targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
If toolchain installed with rustup, this automatically downloads the correct toolchain version